### PR TITLE
feat: Removing explicit dialect register

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ export FIREBOLT_BASE_URL=<your_url>
 
 ```python
 from sqlalchemy import create_engine
-from firebolt_db.firebolt_dialect import FireboltDialect
-from sqlalchemy.dialects import registry
 
-registry.register("firebolt", "src.firebolt_db.firebolt_dialect", "FireboltDialect")
 engine = create_engine("firebolt://email@domain:password@sample_database/sample_engine")
 connection = engine.connect()
 
@@ -63,11 +60,8 @@ for item in result.fetchall():
 ```python
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
-from firebolt_db.firebolt_async_dialect import AsyncFireboltDialect
-from sqlalchemy.dialects import registry
 
-registry.register("firebolt", "src.firebolt_db.firebolt_async_dialect", "AsyncFireboltDialect")
-engine = create_async_engine("firebolt://email@domain:password@sample_database/sample_engine")
+engine = create_async_engine("asyncio+firebolt://email@domain:password@sample_database/sample_engine")
 
 async with engine.connect() as conn:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 download_url = https://github.com/firebolt-db/firebolt-sqlalchemy/archive/refs/tags/0.0.9.tar.gz
-entry_points =
-    sqlalchemy.dialects :
-    firebolt = firebolt_db.firebolt_dialect:FireboltDialect
 project_urls =
     Bug Tracker = https://github.com/firebolt-db/firebolt-sqlalchemy
 
@@ -37,6 +34,11 @@ package_dir =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+sqlalchemy.dialects =
+    firebolt = firebolt_db.firebolt_dialect:FireboltDialect
+    asyncio.firebolt = firebolt_db.firebolt_async_dialect:AsyncFireboltDialect
 
 [options.extras_require]
 dev =

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@ from os import environ
 import nest_asyncio
 from pytest import fixture
 from sqlalchemy import create_engine
-from sqlalchemy.dialects import registry
 from sqlalchemy.engine.base import Connection, Engine
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -49,7 +48,6 @@ def password() -> str:
 def engine(
     username: str, password: str, database_name: str, engine_name: str
 ) -> Engine:
-    registry.register("firebolt", "src.firebolt_db.firebolt_dialect", "FireboltDialect")
     return create_engine(
         f"firebolt://{username}:{password}@{database_name}/{engine_name}"
     )
@@ -72,11 +70,8 @@ def event_loop():
 def async_engine(
     username: str, password: str, database_name: str, engine_name: str
 ) -> Engine:
-    registry.register(
-        "firebolt_aio", "src.firebolt_db.firebolt_async_dialect", "AsyncFireboltDialect"
-    )
     return create_async_engine(
-        f"firebolt_aio://{username}:{password}@{database_name}/{engine_name}"
+        f"asyncio+firebolt://{username}:{password}@{database_name}/{engine_name}"
     )
 
 


### PR DESCRIPTION
This setting automatically registers the dialect with the sqlalchemy so the users don't need to manually call `registry.register`
https://docs.sqlalchemy.org/en/14/core/connections.html#registering-new-dialects
