### PR TITLE
ci: fix environment variable name

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -38,6 +38,6 @@ jobs:
           ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
           STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
           STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
-          API_ENDPOINT: "api.dev.firebolt.io"
+          FIREBOLT_BASE_URL: "api.dev.firebolt.io"
         run: |
           pytest -o log_cli=true -o log_cli_level=INFO tests/integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
           STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
           STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
-          API_ENDPOINT: "api.dev.firebolt.io"
+          FIREBOLT_BASE_URL: "api.dev.firebolt.io"
         run: |
           pytest -o log_cli=true -o log_cli_level=INFO tests/integration
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,13 +2,10 @@ import asyncio
 from logging import getLogger
 from os import environ
 
-import nest_asyncio
 from pytest import fixture
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Connection, Engine
 from sqlalchemy.ext.asyncio import create_async_engine
-
-nest_asyncio.apply()
 
 LOGGER = getLogger(__name__)
 


### PR DESCRIPTION
Sqlalchemy uses a different env variable for url override. Also removing nest_asyncio.