### PR TITLE
fix: temporary Redash compatibility

### DIFF
--- a/src/firebolt_db/firebolt_connector.py
+++ b/src/firebolt_db/firebolt_connector.py
@@ -1,0 +1,25 @@
+from firebolt.db import connect
+
+
+class Connection:
+    """
+    Compatibility layer for Redash.
+    Will be removed once the new version using the SDK is rolled out.
+    """
+
+    def __new__(
+        cls,
+        host,
+        port,
+        username,
+        password,
+        db_name,
+        context=None,
+        header=False,
+        ssl_verify_cert=False,
+        ssl_client_cert=None,
+        proxies=None,
+    ) -> None:
+        return connect(
+            engine_url=host, database=db_name, username=username, password=password
+        )

--- a/src/firebolt_db/firebolt_connector.py
+++ b/src/firebolt_db/firebolt_connector.py
@@ -9,17 +9,17 @@ class Connection:
 
     def __new__(
         cls,
-        host,
-        port,
-        username,
-        password,
-        db_name,
-        context=None,
-        header=False,
-        ssl_verify_cert=False,
-        ssl_client_cert=None,
-        proxies=None,
-    ) -> None:
+        host: str,
+        port: str,
+        username: str,
+        password: str,
+        db_name: str,
+        context: str = None,
+        header: bool = False,
+        ssl_verify_cert: bool = False,
+        ssl_client_cert: str = None,
+        proxies: str = None,
+    ) -> "Connection":
         return connect(
             engine_url=host, database=db_name, username=username, password=password
         )


### PR DESCRIPTION
Redash was relying on old implementation when DBAPI layer was present in the sqlalchemy connector: https://github.com/getredash/redash/blob/master/redash/query_runner/firebolt.py#L2
This aims to make the current module compatible while Redash connector is moving to use the SDK.

Testing: verified functionality by installing the module locally and accessing the Connection class as in redash query_runner.