### PR TITLE
feat: Adding set parameters

### DIFF
--- a/src/firebolt_db/firebolt_async_dialect.py
+++ b/src/firebolt_db/firebolt_async_dialect.py
@@ -8,8 +8,9 @@ import firebolt.async_db as async_dbapi
 from firebolt.async_db import Connection
 
 # Ignoring type since sqlalchemy-stubs doesn't cover AdaptedConnection
+# and util.concurrency
 from sqlalchemy.engine import AdaptedConnection  # type: ignore[attr-defined]
-from sqlalchemy.util.concurrency import await_only
+from sqlalchemy.util.concurrency import await_only  # type: ignore[import]
 
 from firebolt_db.firebolt_dialect import FireboltDialect
 

--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -262,7 +262,13 @@ class FireboltDialect(default.DefaultDialect):
     ) -> str:
         pass
 
-    def do_execute(self, cursor, statement, parameters, context):
+    def do_execute(
+        self,
+        cursor: dbapi.Cursor,
+        statement: str,
+        parameters: Tuple[str, Any],
+        context: ExecutionContext,
+    ):
         cursor.execute(statement, set_parameters=self._set_parameters)
 
     def do_rollback(self, dbapi_connection: AlchemyConnection) -> None:

--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -87,7 +87,7 @@ class FireboltDialect(default.DefaultDialect):
     returns_unicode_strings = True
     description_encoding = None
     supports_native_boolean = True
-    _set_parameters: Dict[str, Any] = None
+    _set_parameters: Optional[Dict[str, Any]] = None
 
     def __init__(
         self, context: Optional[ExecutionContext] = None, *args: Any, **kwargs: Any

--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -110,6 +110,8 @@ class FireboltDialect(default.DefaultDialect):
         # If URL override is not provided leave it to the sdk to determine the endpoint
         if "FIREBOLT_BASE_URL" in os.environ:
             kwargs["api_endpoint"] = os.environ["FIREBOLT_BASE_URL"]
+        if "FIREBOLT_ACCOUNT" in os.environ:
+            kwargs["account_name"] = os.environ["FIREBOLT_ACCOUNT"]
         return ([], kwargs)
 
     def get_schema_names(

--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import firebolt.db as dbapi
 import sqlalchemy.types as sqltypes
+from firebolt.db import Cursor
 from sqlalchemy.engine import Connection as AlchemyConnection
 from sqlalchemy.engine import ExecutionContext, default
 from sqlalchemy.engine.url import URL
@@ -264,11 +265,11 @@ class FireboltDialect(default.DefaultDialect):
 
     def do_execute(
         self,
-        cursor: dbapi.Cursor,
+        cursor: Cursor,
         statement: str,
         parameters: Tuple[str, Any],
-        context: ExecutionContext,
-    ):
+        context: Optional[ExecutionContext] = None,
+    ) -> None:
         cursor.execute(statement, set_parameters=self._set_parameters)
 
     def do_rollback(self, dbapi_connection: AlchemyConnection) -> None:

--- a/tests/integration/test_sqlalchemy_integration.py
+++ b/tests/integration/test_sqlalchemy_integration.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Connection, Engine
 from sqlalchemy.exc import OperationalError
 
@@ -16,6 +17,18 @@ class TestFireboltDialect:
         # Cleanup
         connection.execute(f"DROP TABLE {ex_table_name}")
         assert not engine.dialect.has_table(engine, ex_table_name)
+
+    def test_set_params(
+        self, username: str, password: str, database_name: str, engine_name: str
+    ):
+        engine = create_engine(
+            f"firebolt://{username}:{password}@{database_name}/{engine_name}?"
+            "advanced_mode=1&use_standard_sql=0"
+        )
+        with engine.connect() as connection:
+            result = connection.execute("SELECT sleepEachRow(1) from numbers(1)")
+            assert len(result.fetchall()) == 1
+        engine.dispose()
 
     def test_data_write(self, connection: Connection, fact_table_name: str):
         connection.execute(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,6 +37,20 @@ class MockDBApi:
         pass
 
 
+class MockCursor:
+    def execute():
+        pass
+
+    def executemany():
+        pass
+
+    def fetchall():
+        pass
+
+    def close():
+        pass
+
+
 class MockAsyncDBApi:
     class DatabaseError:
         pass
@@ -98,6 +112,11 @@ def async_dialect() -> firebolt_async_dialect.AsyncFireboltDialect:
 @fixture
 def connection() -> mock.Mock(spec=MockDBApi):
     return mock.Mock(spec=MockDBApi)
+
+
+@fixture
+def cursor() -> mock.Mock(spec=MockCursor):
+    return mock.Mock(spec=MockCursor)
 
 
 @fixture


### PR DESCRIPTION
Ability to pass set parameters to the cursor. Since sqlalchemy is firm on `execute()` signature those have to be passed via the connection string.