### PR TITLE
chore: unpin SDK version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    firebolt-sdk==0.9.2
+    firebolt-sdk>=0.9.2
     sqlalchemy>=1.0.0
 python_requires = >=3.7
 package_dir =

--- a/src/firebolt_db/firebolt_async_dialect.py
+++ b/src/firebolt_db/firebolt_async_dialect.py
@@ -57,19 +57,17 @@ class AsyncCursorWrapper:
         self,
         operation: str,
         parameters: Optional[Tuple] = None,
-        set_parameters: Optional[Dict] = None,
     ) -> None:
-        self.await_(self._execute(operation, parameters, set_parameters=set_parameters))
+        self.await_(self._execute(operation, parameters))
 
     async def _execute(
         self,
         operation: str,
         parameters: Optional[Tuple] = None,
-        set_parameters: Optional[Dict] = None,
     ) -> None:
         async with self._adapt_connection._execute_mutex:
             await self._cursor.execute(
-                operation, parameters, set_parameters=set_parameters
+                operation, parameters
             )
             if self._cursor.description:
                 self._rows = await self._cursor.fetchall()

--- a/src/firebolt_db/firebolt_async_dialect.py
+++ b/src/firebolt_db/firebolt_async_dialect.py
@@ -66,9 +66,7 @@ class AsyncCursorWrapper:
         parameters: Optional[Tuple] = None,
     ) -> None:
         async with self._adapt_connection._execute_mutex:
-            await self._cursor.execute(
-                operation, parameters
-            )
+            await self._cursor.execute(operation, parameters)
             if self._cursor.description:
                 self._rows = await self._cursor.fetchall()
             else:

--- a/tests/unit/test_firebolt_async_dialect.py
+++ b/tests/unit/test_firebolt_async_dialect.py
@@ -80,7 +80,7 @@ class TestAsyncFireboltDialect:
         assert wrapper.description == "dummy"
         assert wrapper.rowcount == -1
         async_cursor.execute.assert_awaited_once_with(
-            "INSERT INTO test(a, b) VALUES (?, ?)", [(1, "a")], set_parameters=None
+            "INSERT INTO test(a, b) VALUES (?, ?)", [(1, "a")]
         )
         async_cursor.fetchall.assert_awaited_once()
 
@@ -105,7 +105,7 @@ class TestAsyncFireboltDialect:
         assert wrapper.description is None
         assert wrapper.rowcount == 100
         async_cursor.execute.assert_awaited_once_with(
-            "INSERT INTO test(a, b) VALUES (?, ?)", [(1, "a")], set_parameters=None
+            "INSERT INTO test(a, b) VALUES (?, ?)", [(1, "a")]
         )
         async_cursor.fetchall.assert_not_awaited()
 


### PR DESCRIPTION
Also removing the leftover set parameter logic. All of it lives in `firebolt_dialect.py`