### PR TITLE
test: Compatibility with alchemy 2.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ sqlalchemy.dialects =
 [options.extras_require]
 dev =
     devtools==0.7.0
+    greenlet==2.0.2
     mock==4.0.3
     mypy==0.910
     pre-commit==2.15.0

--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -148,6 +148,7 @@ class FireboltDialect(default.DefaultDialect):
         connection: AlchemyConnection,
         table_name: str,
         schema: Optional[str] = None,
+        **kw: Any
     ) -> bool:
         query = """
             select count(*) > 0 as exists_

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from os import environ
 
 from pytest import fixture
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine.base import Connection, Engine
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -157,28 +157,32 @@ def setup_test_tables(
     dimension_table_name: str,
 ):
     connection.execute(
-        f"""
+        text(
+            f"""
         CREATE FACT TABLE IF NOT EXISTS {fact_table_name}
         (
             idx INT,
             dummy TEXT
         ) PRIMARY INDEX idx;
         """
+        )
     )
     connection.execute(
-        f"""
+        text(
+            f"""
         CREATE DIMENSION TABLE IF NOT EXISTS {dimension_table_name}
         (
             idx INT,
             dummy TEXT
         );
         """
+        )
     )
-    assert engine.dialect.has_table(engine, fact_table_name)
-    assert engine.dialect.has_table(engine, dimension_table_name)
+    assert engine.dialect.has_table(connection, fact_table_name)
+    assert engine.dialect.has_table(connection, dimension_table_name)
     yield
     # Teardown
-    connection.execute(f"DROP TABLE IF EXISTS {fact_table_name} CASCADE;")
-    connection.execute(f"DROP TABLE IF EXISTS {dimension_table_name} CASCADE;")
-    assert not engine.dialect.has_table(engine, fact_table_name)
-    assert not engine.dialect.has_table(engine, dimension_table_name)
+    connection.execute(text(f"DROP TABLE IF EXISTS {fact_table_name} CASCADE;"))
+    connection.execute(text(f"DROP TABLE IF EXISTS {dimension_table_name} CASCADE;"))
+    assert not engine.dialect.has_table(connection, fact_table_name)
+    assert not engine.dialect.has_table(connection, dimension_table_name)


### PR DESCRIPTION
With sqlalchemy 2.0.1 our tests are failing. Some of the functionality that has been deprecated has been removed now.
This is correcting some of the function signatures and the way we call them. Also adding a library that's used in tests but no longer used in sqlalchemy.

Tests are passing for both sqlalchemy==1.* and 2.0.1