### PR TITLE
ci: Fix pre-commit

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -12,10 +12,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     
     - name: Install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - --remove-unused-variables
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: "5.12.0"
     hooks:
       - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: black_nbconvert
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.7.9
+    rev: "4.0.1"
     hooks:
       - id: flake8
         additional_dependencies:

--- a/tests/integration/test_sqlalchemy_async_integration.py
+++ b/tests/integration/test_sqlalchemy_async_integration.py
@@ -52,14 +52,14 @@ class TestAsyncFireboltDialect:
 
     @pytest.mark.asyncio
     async def test_set_params(self, async_connection: Engine):
-        await async_connection.execute(text(f"SET advanced_mode=1"))
-        await async_connection.execute(text(f"SET use_standard_sql=0"))
+        await async_connection.execute(text("SET advanced_mode=1"))
+        await async_connection.execute(text("SET use_standard_sql=0"))
         result = await async_connection.execute(
-            text(f"SELECT sleepEachRow(1) from numbers(1)")
+            text("SELECT sleepEachRow(1) from numbers(1)")
         )
         assert len(result.fetchall()) == 1
-        await async_connection.execute(text(f"SET use_standard_sql=1"))
-        await async_connection.execute(text(f"SET advanced_mode=0"))
+        await async_connection.execute(text("SET use_standard_sql=1"))
+        await async_connection.execute(text("SET advanced_mode=0"))
 
     @pytest.mark.asyncio
     async def test_get_table_names(self, async_connection: Connection):


### PR DESCRIPTION
Analogous to fix in https://github.com/firebolt-db/firebolt-python-sdk/pull/238
This is needed since isort no longer works with an update to one of its dependencies.