### PR TITLE
lock sdk version to 0.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    firebolt-sdk>=0.9.2
+    firebolt-sdk>=0.9.2,<1.0.0
     sqlalchemy>=1.0.0
 python_requires = >=3.7
 package_dir =


### PR DESCRIPTION
Lock python sdk version to only use 0.x versions