### PR TITLE
ci: call integration tests from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,44 +12,12 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[dev]"
-
-      - name: Setup database and engine
-        id: setup
-        uses: firebolt-db/integration-testing-setup@v1
-        with:
-          firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
-          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
-          api-endpoint: "api.dev.firebolt.io"
-          region: "us-east-1"
-
-      - name: Run integration tests
-        env:
-          USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
-          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
-          SERVICE_ID: ${{ secrets.SERVICE_ID }}
-          SERVICE_SECRET: ${{ secrets.SERVICE_SECRET }}
-          DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
-          ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-          ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
-          STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
-          STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
-          FIREBOLT_BASE_URL: "api.dev.firebolt.io"
-        run: |
-          pytest -o log_cli=true -o log_cli_level=INFO tests/integration
+    uses: ./.github/workflows/python-integration-tests.yml
+    secrets:
+      FIREBOLT_CLIENT_ID_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+      FIREBOLT_CLIENT_SECRET_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
+      FIREBOLT_CLIENT_ID_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_ID_NEW_IDN }}
+      FIREBOLT_CLIENT_SECRET_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_NEW_IDN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated release.yml to call integration tests from `python-integration-tests.yml` instead of running them manually 