### PR TITLE
fix: Make account name optional

### DIFF
--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -153,7 +153,8 @@ class FireboltDialect(default.DefaultDialect):
         additional_parameters = {}
         if "account_name" in parameters:
             kwargs["account_name"] = parameters.pop("account_name")
-        else:
+        elif isinstance(auth, ClientCredentials):
+            # account_name is required for client credentials authentication
             raise ArgumentError(
                 "account_name parameter must be provided to authenticate"
             )

--- a/tests/unit/test_firebolt_dialect.py
+++ b/tests/unit/test_firebolt_dialect.py
@@ -36,7 +36,6 @@ class TestFireboltDialect:
     def test_create_connect_args_user_password(self, dialect: FireboltDialect):
         u = url.make_url(
             "test_engine://test-sa@user.com:test_password@test_db_name/test_engine_name"
-            "?account_name=dummy"
         )
         with mock.patch.dict(os.environ, {"FIREBOLT_BASE_URL": "test_url"}):
             result_list, result_dict = dialect.create_connect_args(u)


### PR DESCRIPTION
We had a bug when account name was required despite using a username password authentication.