### PR TITLE
fix: Addresses SA warnings

### DIFF
--- a/src/firebolt_db/firebolt_dialect.py
+++ b/src/firebolt_db/firebolt_dialect.py
@@ -119,6 +119,9 @@ class FireboltDialect(default.DefaultDialect):
     supports_empty_insert = False
     supports_unicode_statements = True
     supports_unicode_binds = True
+    supports_statement_cache = False
+    # supports_statement_cache Set to False to disable warning
+    # https://sqlalche.me/e/20/cprf
     returns_unicode_strings = True
     description_encoding = None
     supports_native_boolean = True
@@ -131,7 +134,11 @@ class FireboltDialect(default.DefaultDialect):
         self.context: Union[ExecutionContext, Dict] = context or {}
 
     @classmethod
-    def dbapi(cls) -> ModuleType:
+    def import_dbapi(cls) -> ModuleType:  # For sqlalchemy >= 2.0.0
+        return dbapi
+
+    @classmethod
+    def dbapi(cls) -> ModuleType:  # Kept for backwards compatibility
         return dbapi
 
     def create_connect_args(self, url: URL) -> Tuple[List, Dict]:


### PR DESCRIPTION
This PR addresses two warnings coming from SqlAlchemy:

* `SADeprecationWarning` when sqlalchemy version 2 when creating the engine
* `SAWarning` because the attribute `supports_statement_cache` is not set

If I run this code on sqlalchemy `2.0.29`  I get these warnings:
## Sample code:
```python
from sqlalchemy import create_engine, text
import urllib.parse

FIREBOLT_USERNAME = ...
FIREBOLT_PASSWORD = ...
DEFAULT_REGION = ...

SECRET = urllib.parse.quote_plus(FIREBOLT_PASSWORD)

database_name = ...
engine_name = ...
account_name = ... 
uri = f"firebolt://{FIREBOLT_USERNAME}:{SECRET}@{database_name}/{engine_name}?account_name={account_name}"

engine = create_engine(uri)
with engine.connect() as conn:
    conn.execute(text('SELECT 1;'))
```


## Warnings
```

SADeprecationWarning: The dbapi() classmethod on dialect classes has been renamed to import_dbapi().  Implement an import_dbapi() classmethod directly on class <class 'firebolt_db.firebolt_dialect.FireboltDialect'> to remove this warning; the old .dbapi() classmethod may be maintained for backwards compatibility.
  engine = create_engine(uri)

SAWarning: Dialect firebolt:firebolt will not make use of SQL compilation caching as it does not set the 'supports_statement_cache' attribute to ``True``.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Dialect maintainers should seek to set this attribute to True after appropriate development and testing for SQLAlchemy 1.4 caching support.   Alternatively, this attribute may be set to False which will disable this warning. (Background on this warning at: https://sqlalche.me/e/20/cprf)
  conn.execute(text('SELECT 1;'))

```

With the changes on this PR, these warnings will not be present.