### PR TITLE
build: Limit sqlalchemy to below 2.0.28

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ project_urls =
 packages = find:
 install_requires =
     firebolt-sdk>=1.1.0
-    sqlalchemy>=1.0.0
+    sqlalchemy>=1.0.0,<2.0.28
 python_requires = >=3.7
 package_dir =
     = src


### PR DESCRIPTION
Sqlalchemy>=2.0.28 introduces changes that break our async dialect as reported in #96 .
Limiting the version to avoid breaking existing processes.