### PR TITLE
ci: Limit macos runner to version 13

### DIFF
--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-13', 'windows-latest']
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Check out code

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-13', 'windows-latest']
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Check out code


### PR DESCRIPTION
As referenced in https://github.com/actions/setup-python/issues/852 there are issues with setup python and the latest macos runner. Limiting it to 13 to allow tests to pass.