### PR TITLE
build: Update Firebolt SDK to at least 1.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    firebolt-sdk>=1.1.0
+    firebolt-sdk>=1.5.0
     sqlalchemy>=1.0.0
 python_requires = >=3.7
 package_dir =


### PR DESCRIPTION
Bump to make sure the users get the latest features like autostart of the engines.