### PR TITLE
fix(FIR-50880): Async close failure

### DIFF
--- a/src/firebolt_db/firebolt_async_dialect.py
+++ b/src/firebolt_db/firebolt_async_dialect.py
@@ -109,6 +109,15 @@ class AsyncCursorWrapper:
     def _set_parameters(self, value: Dict[str, Any]) -> None:
         self._cursor._set_parameters = value
 
+    async def _async_soft_close(self) -> None:
+        """close the cursor but keep the results pending, and memoize the
+        description.
+
+        We don't have ability to memorize results with async driver yet so
+        keeping this a no-op.
+
+        """
+
 
 class AsyncConnectionWrapper(AdaptedConnection):
     await_ = staticmethod(await_only)


### PR DESCRIPTION
Starting from `sqlalchemy==2.0.44` it uses _async_soft_close to safely close the cursor behind the scenes.
Since we create our own wrappers we don't have this method and fail on such call. Adding a stub for it to avoid failures.
For a long-term solution we should migrate to AsyncIODBAPICursor. This will be done as a separate PR since it requires more changes and testing.

Closes #113